### PR TITLE
Update media_profiles.xml

### DIFF
--- a/configs/media_profiles.xml
+++ b/configs/media_profiles.xml
@@ -81,61 +81,61 @@
   <!-- Back Camera -->
   <CamcorderProfiles cameraId="0">
 
-    <EncoderProfile quality="qvga" fileFormat="mp4" duration="30">
+    <EncoderProfile quality="qvga" fileFormat="mp4" duration="60">
       <Video codec="h264"
-             bitRate="384000"
+             bitRate="30000000"
              width="320"
              height="240"
-             frameRate="15" />
+             frameRate="30" />
 
       <Audio codec="aac"
-             bitRate="128000"
+             bitRate="192000"
              sampleRate="48000"
              channels="2" />
     </EncoderProfile>
 
-    <EncoderProfile quality="480p" fileFormat="mp4" duration="30">
+    <EncoderProfile quality="480p" fileFormat="mp4" duration="60">
       <Video codec="h264"
-             bitRate="3078000"
+             bitRate="30000000"
              width="640"
              height="480"
              frameRate="30" />
 
       <Audio codec="aac"
-             bitRate="128000"
+             bitRate="192000"
              sampleRate="48000"
              channels="2" />
     </EncoderProfile>
 
-    <EncoderProfile quality="720p" fileFormat="mp4" duration="30">
+    <EncoderProfile quality="720p" fileFormat="mp4" duration="60">
       <Video codec="h264"
-             bitRate="12000000"
+             bitRate="30000000"
              width="1280"
              height="720"
              frameRate="30" />
 
       <Audio codec="aac"
-             bitRate="128000"
+             bitRate="192000"
              sampleRate="48000"
              channels="2" />
     </EncoderProfile>
 
-    <EncoderProfile quality="1080p" fileFormat="mp4" duration="30">
+    <EncoderProfile quality="1080p" fileFormat="mp4" duration="60">
       <Video codec="h264"
-             bitRate="17000000"
+             bitRate="30000000"
              width="1920"
              height="1080"
              frameRate="30" />
 
       <Audio codec="aac"
-             bitRate="196000"
+             bitRate="192000"
              sampleRate="48000"
              channels="2" />
     </EncoderProfile>
 
-    <EncoderProfile quality="timelapseqcif" fileFormat="3gp" duration="30">
+    <EncoderProfile quality="timelapseqcif" fileFormat="3gp" duration="60">
       <Video codec="h264"
-             bitRate="384000"
+             bitRate="30000000"
              width="176"
              height="144"
              frameRate="30" />
@@ -145,14 +145,14 @@
             does not capture audio
       -->
       <Audio codec="aac"
-             bitRate="128000"
+             bitRate="192000"
              sampleRate="48000"
-             channels="1" />
+             channels="2" />
     </EncoderProfile>
 
-    <EncoderProfile quality="timelapse480p" fileFormat="mp4" duration="30">
+    <EncoderProfile quality="timelapse480p" fileFormat="mp4" duration="60">
       <Video codec="h264"
-             bitRate="3078000"
+             bitRate="30000000"
              width="640"
              height="480"
              frameRate="30" />
@@ -162,14 +162,14 @@
             does not capture audio
       -->
       <Audio codec="aac"
-             bitRate="128000"
+             bitRate="192000"
              sampleRate="48000"
-             channels="1" />
+             channels="2" />
     </EncoderProfile>
 
-    <EncoderProfile quality="timelapse720p" fileFormat="mp4" duration="30">
+    <EncoderProfile quality="timelapse720p" fileFormat="mp4" duration="60">
       <Video codec="h264"
-             bitRate="12000000"
+             bitRate="30000000"
              width="1280"
              height="720"
              frameRate="30" />
@@ -179,14 +179,14 @@
             does not capture audio
       -->
       <Audio codec="aac"
-             bitRate="128000"
+             bitRate="192000"
              sampleRate="48000"
-             channels="1" />
+             channels="2" />
     </EncoderProfile>
 
-    <EncoderProfile quality="timelapse1080p" fileFormat="mp4" duration="30">
+    <EncoderProfile quality="timelapse1080p" fileFormat="mp4" duration="60">
       <Video codec="h264"
-             bitRate="17000000"
+             bitRate="30000000"
              width="1920"
              height="1080"
              frameRate="30" />
@@ -196,12 +196,12 @@
             does not capture audio
       -->
       <Audio codec="aac"
-             bitRate="128000"
+             bitRate="192000"
              sampleRate="48000"
-             channels="1" />
+             channels="2" />
     </EncoderProfile>
 
-    <ImageEncoding quality="90" />
+    <ImageEncoding quality="100" />
     <ImageEncoding quality="80" />
     <ImageEncoding quality="70" />
     <ImageDecoding memCap="20000000" />
@@ -211,48 +211,48 @@
   <!-- Front Camera -->
   <CamcorderProfiles cameraId="1">
 
-    <EncoderProfile quality="qvga" fileFormat="3gp" duration="30">
+    <EncoderProfile quality="qvga" fileFormat="3gp" duration="60">
       <Video codec="h264"
-             bitRate="384000"
+             bitRate="30000000"
              width="320"
              height="240"
-             frameRate="15" />
+             frameRate="30" />
 
       <Audio codec="aac"
-             bitRate="128000"
+             bitRate="192000"
              sampleRate="48000"
-             channels="1" />
+             channels="2" />
     </EncoderProfile>
 
-    <EncoderProfile quality="480p" fileFormat="mp4" duration="30">
+    <EncoderProfile quality="480p" fileFormat="mp4" duration="60">
       <Video codec="h264"
-             bitRate="3078000"
+             bitRate="30000000"
              width="640"
              height="480"
              frameRate="30" />
 
       <Audio codec="aac"
-             bitRate="128000"
+             bitRate="192000"
              sampleRate="48000"
-             channels="1" />
+             channels="2" />
     </EncoderProfile>
 
-    <EncoderProfile quality="720p" fileFormat="mp4" duration="30">
+    <EncoderProfile quality="720p" fileFormat="mp4" duration="60">
       <Video codec="h264"
-             bitRate="12000000"
+             bitRate="30000000"
              width="1280"
              height="720"
              frameRate="30" />
 
       <Audio codec="aac"
-             bitRate="128000"
+             bitRate="192000"
              sampleRate="48000"
-             channels="1" />
+             channels="2" />
     </EncoderProfile>
 
-    <EncoderProfile quality="timelapseqcif" fileFormat="3gp" duration="30">
+    <EncoderProfile quality="timelapseqcif" fileFormat="3gp" duration="60">
       <Video codec="h264"
-             bitRate="384000"
+             bitRate="30000000"
              width="176"
              height="144"
              frameRate="30" />
@@ -262,14 +262,14 @@
             does not capture audio
       -->
       <Audio codec="aac"
-             bitRate="128000"
+             bitRate="192000"
              sampleRate="48000"
-             channels="1" />
+             channels="2" />
     </EncoderProfile>
 
-    <EncoderProfile quality="timelapse480p" fileFormat="mp4" duration="30">
+    <EncoderProfile quality="timelapse480p" fileFormat="mp4" duration="60">
       <Video codec="h264"
-             bitRate="3078000"
+             bitRate="30000000"
              width="640"
              height="480"
              frameRate="30" />
@@ -279,12 +279,12 @@
             does not capture audio
       -->
       <Audio codec="aac"
-             bitRate="128000"
+             bitRate="192000"
              sampleRate="48000"
-             channels="1" />
+             channels="2" />
     </EncoderProfile>
 
-    <ImageEncoding quality="90" />
+    <ImageEncoding quality="100" />
     <ImageEncoding quality="80" />
     <ImageEncoding quality="70" />
     <ImageDecoding memCap="20000000" />
@@ -300,10 +300,10 @@
          or query the capabilities of the codec at all if it is disabled
     -->
   <VideoEncoderCap name="h264" enabled="true"
-      minBitRate="64000" maxBitRate="20000000"
+      minBitRate="30000000" maxBitRate="30000000"
       minFrameWidth="176" maxFrameWidth="1920"
       minFrameHeight="144" maxFrameHeight="1080"
-      minFrameRate="1" maxFrameRate="30" />
+      minFrameRate="30" maxFrameRate="30" />
 
   <VideoEncoderCap name="h263" enabled="true"
       minBitRate="64000" maxBitRate="1000000"
@@ -312,15 +312,15 @@
       minFrameRate="1" maxFrameRate="30" />
 
   <VideoEncoderCap name="m4v" enabled="true"
-      minBitRate="64000" maxBitRate="20000000"
+      minBitRate="30000000" maxBitRate="30000000"
       minFrameWidth="176" maxFrameWidth="1920"
       minFrameHeight="144" maxFrameHeight="1080"
-      minFrameRate="1" maxFrameRate="30" />
+      minFrameRate="30" maxFrameRate="30" />
 
   <AudioEncoderCap name="aac" enabled="true"
-      minBitRate="8192" maxBitRate="196000"
-      minSampleRate="8000" maxSampleRate="48000"
-      minChannels="1" maxChannels="2" />
+      minBitRate="192000" maxBitRate="192000"
+      minSampleRate="48000" maxSampleRate="48000"
+      minChannels="2" maxChannels="2" />
 
   <AudioEncoderCap name="amrwb" enabled="true"
       minBitRate="6600" maxBitRate="23050"


### PR DESCRIPTION
- Fixed 720p front facing video recording, from mono to stereo audio.
- Set max recording duration to 60 min on all resolutions.
- Set picture quality from 90% to 100%.
- Try to set/force video recording to "30fps @ 30mbit bitrate (mp4, h264/m4v)" and "stereo audio at 192kbit/s @ 48000hz (aac)" on all resolutions. Audio and fps somewhat working, but camera app ignores bitrate depending on light conditions.
